### PR TITLE
Fixed get user avatar

### DIFF
--- a/src/api/actions.ts
+++ b/src/api/actions.ts
@@ -177,12 +177,13 @@ const getUser = async (platformUserId: number) => {
   }
 
   const blob = await axios.get(
-    `https://api.telegram.org/file/bot${config.telegramToken}/${fileInfo.data.result.file_path}`
+    `https://api.telegram.org/file/bot${config.telegramToken}/${fileInfo.data.result.file_path}`,
+    { responseType: "arraybuffer" }
   );
 
   return {
     username: (chat as any).username,
-    avatar: blob.data
+    avatar: `data:image/jpeg;base64,${blob.data.toString("base64")}`
   };
 };
 


### PR DESCRIPTION
Fixed fetching avatar as blob, encoding it in base64, and addig `data:image/jpeg;base64,` prefix in response.